### PR TITLE
update and fix 'get_denominator()' function

### DIFF
--- a/gptsenpy/utils/utils.py
+++ b/gptsenpy/utils/utils.py
@@ -117,7 +117,11 @@ def clean_values(
     return ret_dict
 
 
-def get_denominator(values: dict[str, bool | set[Num] | list[Num]]) -> int:
+def get_denominator(
+    values: dict[str, bool | set[Num]]
+    | dict[str, bool | list[Num]]
+    | dict[str, bool | set[Num] | list[Num]]
+) -> int:
     """
     Calculates the denominator for a fraction based on the given dictionary of values.
 

--- a/gptsenpy/utils/utils.py
+++ b/gptsenpy/utils/utils.py
@@ -117,12 +117,13 @@ def clean_values(
     return ret_dict
 
 
-def get_denominator(values: dict[str, bool | set[Num]]) -> int:
+def get_denominator(values: dict[str, bool | set[Num] | list[Num]]) -> int:
     """
     Calculates the denominator for a fraction based on the given dictionary of values.
 
     Args:
-        values (dict[str, bool | set[Num]]): A dictionary of values where the keys are strings and the values are either boolean or sets of numbers.
+        values (dict[str, bool | set[Num] | list[Num]]): A dictionary of values where the keys are strings and the values take either bool, set of numerical values, or list of numerical values.
+
 
     Returns:
         int: The denominator for the fraction, which is the sum of the number of values in each set and the number of boolean values.
@@ -132,11 +133,11 @@ def get_denominator(values: dict[str, bool | set[Num]]) -> int:
 
     Example:
         >>> get_denominator({'a': True, 'b': False, 'c': {'d', 'e', 'f'}})
-        4
+        5
     """
     ret = 0
     for v in values.values():
-        if isinstance(v, set):
+        if isinstance(v, set | list):
             ret += len(v)
         else:
             ret += 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,22 @@ import sys
 
 sys.path.append("../gptsenpy")
 from gptsenpy.io.read import read_json
-from gptsenpy.utils import clean_values, concat_json_result
+from gptsenpy.utils import clean_values, concat_json_result, get_denominator
+
+
+def test_get_denominator_0():
+    dct = {}
+    assert get_denominator(dct) == 0
+
+
+def test_get_denominator_1():
+    dct = {"a": True, "b": False, "c": {"d", "e", "f"}}
+    assert get_denominator(dct) == 5
+
+
+def test_get_denominator_1():
+    dct = {"a": True, "b": {1, 2, 3}, "c": [4, 5]}
+    assert get_denominator(dct) == 6
 
 
 def test_clean_values_null():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ def test_get_denominator_1():
     assert get_denominator(dct) == 5
 
 
-def test_get_denominator_1():
+def test_get_denominator_2():
     dct = {"a": True, "b": {1, 2, 3}, "c": [4, 5]}
     assert get_denominator(dct) == 6
 


### PR DESCRIPTION
moonshotプロジェクトの `data.csv` の間違いの原因になっていたため、 `get_denominator()` 関数をリストにも対応させました。
合わせて、テストの追加と、docstringの間違いの修正を行いました。