### PR TITLE
update 'Metrics' class and aggregation

### DIFF
--- a/gptsenpy/metrics/__init__.py
+++ b/gptsenpy/metrics/__init__.py
@@ -1,1 +1,1 @@
-from .metrics import Metrics
+from .metrics import MetricGroup, Metrics

--- a/gptsenpy/metrics/metrics.py
+++ b/gptsenpy/metrics/metrics.py
@@ -44,13 +44,13 @@ class MetricGroup:
             else 0.0
         )
         self.num_labels = (
-            sum(self.num_labels_dct.values()) if self.num_labels_dct.values() else 0.0
+            sum(self.num_labels_dct.values()) if self.num_labels_dct.values() else 0
         )
         self.num_preds = (
-            sum(self.num_preds_dct.values()) if self.num_preds_dct.values() else 0.0
+            sum(self.num_preds_dct.values()) if self.num_preds_dct.values() else 0
         )
 
-    def export_metrics(self) -> dict[str, float]:
+    def export_metrics(self) -> dict[str, int | float]:
         return {
             "recall": self.recall,
             "precision": self.precision,

--- a/gptsenpy/metrics/metrics.py
+++ b/gptsenpy/metrics/metrics.py
@@ -12,29 +12,49 @@ class MetricGroup:
         self.preds = preds
         self.label_category = label_category
 
-        self.recall_lst = []
-        self.precision_lst = []
-        self.num_labels_lst = []
-        self.num_preds_lst = []
+        self.recall_dct = {}
+        self.precision_dct = {}
+        self.f1_dct = {}
+        self.num_labels_dct = {}
+        self.num_preds_dct = {}
 
         for c in label_category:
             label = labels[c] if c in labels else set()
             pred = preds[c] if c in preds else set()
             mt = Metrics(label, pred)
-            self.recall_lst.append(mt.recall)
-            self.precision_lst.append(mt.precision)
-            self.num_labels_lst.append(mt.num_labels)
-            self.num_preds_lst.append(mt.num_preds)
+            self.recall_dct[c] = mt.recall
+            self.precision_dct[c] = mt.precision
+            self.f1_dct[c] = mt.f1
+            self.num_labels_dct[c] = mt.num_labels
+            self.num_preds_dct[c] = mt.num_preds
 
-        self.recall = sum(self.recall_lst) / len(self.recall_lst)
-        self.precision = sum(self.precision_lst) / len(self.precision_lst)
-        self.num_labels = sum(self.num_labels_lst)
-        self.num_preds = sum(self.num_preds_lst)
+        self.recall = (
+            sum(self.recall_dct.values()) / len(self.recall_dct.values())
+            if self.recall_dct.values()
+            else 0.0
+        )
+        self.precision = (
+            sum(self.precision_dct.values()) / len(self.precision_dct.values())
+            if self.precision_dct.values()
+            else 0.0
+        )
+        self.f1 = (
+            sum(self.f1_dct.values()) / len(self.f1_dct.values())
+            if self.f1_dct.values()
+            else 0.0
+        )
+        self.num_labels = (
+            sum(self.num_labels_dct.values()) if self.num_labels_dct.values() else 0.0
+        )
+        self.num_preds = (
+            sum(self.num_preds_dct.values()) if self.num_preds_dct.values() else 0.0
+        )
 
     def export_metrics(self) -> dict[str, float]:
         return {
             "recall": self.recall,
             "precision": self.precision,
+            "f1": self.f1,
             "num_labels": self.num_labels,
             "num_preds": self.num_preds,
         }

--- a/gptsenpy/metrics/metrics.py
+++ b/gptsenpy/metrics/metrics.py
@@ -1,98 +1,74 @@
-from typing import Optional, TypeAlias
-
-from ..utils import clean_values, get_denominator
-
-Num: TypeAlias = int | float
+from ..utils import Num
 
 
 class Metrics:
     def __init__(
         self,
-        labels: dict[str, bool | set[Num] | list[Num]],
-        preds: dict[str, bool | set[Num] | list[Num]],
+        labels: set[str | Num],
+        preds: set[str | Num],
     ):
-        self.labels = clean_values(labels)
-        self.preds = clean_values(preds)
-        self.num_labels: int = self.__get_num_values(self.labels)
-        self.num_preds: int = self.__get_num_values(self.preds)
+        assert isinstance(labels, set)
+        assert isinstance(preds, set)
+        for i in labels:
+            assert isinstance(i, str | Num)
+        for i in preds:
+            assert isinstance(i, str | Num)
 
-        self.precision: float = self.get_precision()
-        self.recall: float = self.get_recall()
-        self.f1: float = self.get_f1()
+        self.labels = labels
+        self.preds = preds
+
+        self.num_labels: int = len(labels)
+        self.num_preds: int = len(preds)
+
+        self.recall: float = self.__get_recall()
+        self.precision: float = self.__get_precision()
+        self.f1: float = self.__get_f1()
 
     def export_metrics(self) -> dict[str, float]:
         return {
-            "precision": self.precision,
             "recall": self.recall,
+            "precision": self.precision,
             "f1": self.f1,
         }
 
-    def __get_num_values(self, dct: dict[str, bool | set[Num]]) -> int:
-        return get_denominator(dct)
-
-    def get_recall(
+    def __get_recall(
         self,
-        labels: Optional[dict[str, bool | set[Num]]] = None,
-        preds: Optional[dict[str, bool | set[Num]]] = None,
+        labels: set[str | Num] | None = None,
+        preds: set[str | Num] | None = None,
     ) -> float:
-        labels = self.get_value_if_none(labels, "labels")
-        preds = self.get_value_if_none(preds, "preds")
+        labels = self.__get_value_if_none(labels, "labels")
+        preds = self.__get_value_if_none(preds, "preds")
+
         if len(labels) == 0:
             return 0.0
 
-        denominator = get_denominator(labels)
-        numerator = 0
-        for k, v in labels.items():
-            if k not in preds.keys():
-                continue
-            if isinstance(v, set):
-                for vv in v:
-                    preds_k = preds[k]
-                    if isinstance(preds_k, set) and vv in preds_k:
-                        numerator += 1
-                        break
-            else:
-                if preds[k] == v:
-                    numerator += 1
-
+        denominator = len(labels)
+        numerator = sum([i in preds for i in labels])
         return numerator / denominator
 
-    def get_precision(
+    def __get_precision(
         self,
-        labels: Optional[dict[str, bool | set[Num]]] = None,
-        preds: Optional[dict[str, bool | set[Num]]] = None,
+        labels: set[str | Num] | None = None,
+        preds: set[str | Num] | None = None,
     ) -> float:
-        labels = self.get_value_if_none(labels, "labels")
-        preds = self.get_value_if_none(preds, "preds")
+        labels = self.__get_value_if_none(labels, "labels")
+        preds = self.__get_value_if_none(preds, "preds")
 
         if len(preds) == 0:
             return 0.0
-        numerator = 0
-        denominator = get_denominator(preds)
-        for k, v in preds.items():
-            if k not in labels.keys():
-                continue
 
-            if isinstance(v, set):
-                for vv in v:
-                    labels_k = labels[k]
-                    if isinstance(labels_k, set) and vv in labels_k:
-                        numerator += 1
-                        break
-            else:
-                if labels[k] == v:
-                    numerator += 1
-
+        denominator = len(preds)
+        numerator = sum([i in labels for i in preds])
         return numerator / denominator
 
-    def get_f1(
+    def __get_f1(
         self,
-        labels: Optional[dict[str, bool | set[Num]]] = None,
-        preds: Optional[dict[str, bool | set[Num]]] = None,
+        labels: set[str | Num] | None = None,
+        preds: set[str | Num] | None = None,
     ) -> float:
-        labels = self.get_value_if_none(labels, "labels")
-        preds = self.get_value_if_none(preds, "preds")
-        recall, precision = self.get_recall(labels, preds), self.get_precision(
+        labels = self.__get_value_if_none(labels, "labels")
+        preds = self.__get_value_if_none(preds, "preds")
+        recall, precision = self.__get_recall(labels, preds), self.__get_precision(
             labels, preds
         )
 
@@ -100,12 +76,12 @@ class Metrics:
             return 0
         return 2 * recall * precision / (recall + precision)
 
-    def get_value_if_none(
-        self, values: Optional[dict] = None, name: Optional[str] = None
-    ) -> dict[str, bool | set[Num]]:
+    def __get_value_if_none(
+        self, values: set | None = None, name: str | None = None
+    ) -> set[str | Num]:
         if values is None and name is not None:
             return getattr(self, name)
         elif values is not None:
-            return clean_values(values)
+            return values
         else:
             raise ValueError("Values and name cannot be None")

--- a/gptsenpy/utils/__init__.py
+++ b/gptsenpy/utils/__init__.py
@@ -1,1 +1,6 @@
-from .utils import clean_values, concat_json_result, get_denominator
+from .utils import (
+    Num,
+    clean_values,
+    categorize_dict_keys,
+    uncategorize_dict_keys,
+)

--- a/gptsenpy/utils/utils.py
+++ b/gptsenpy/utils/utils.py
@@ -107,7 +107,7 @@ def clean_values(
         if isinstance(v, int | float | bool):
             ret_dct[k] = v
         else:
-            raise ValueError(f"Value must be a bool, int, or float")
+            raise ValueError("Value must be a bool, int, or float")
 
     return ret_dct
 

--- a/gptsenpy/utils/utils.py
+++ b/gptsenpy/utils/utils.py
@@ -1,5 +1,5 @@
-from collections import Counter
-from typing import Any, Optional, TypeAlias
+from collections import Counter, defaultdict
+from typing import TypeAlias, cast
 
 
 Num: TypeAlias = int | float | bool
@@ -71,131 +71,155 @@ DEFAULT_KEY = [
 
 
 def clean_values(
-    values: dict[str, bool | list[Num] | set[Num]] | dict[str, list[Num]],
-    key_lst: Optional[list[str]] = None,
-) -> dict[str, bool | set[Num]]:
+    dct: dict[str, Num],
+    key_lst: list[str] = DEFAULT_KEY,
+) -> dict[str, Num]:
     """
-    Cleans a dictionary of values by removing any keys with None or False values, and converting
-    any lists or floats to sets. The resulting dictionary will only contain keys with boolean or
-    set values.
+    Cleans a dictionary by removing any keys with None or False values and any keys that are not included in key_lst.
 
-    Args:
-        values (dict[str, bool | list | set]): A dictionary of values to be cleaned.
+    Parameters
+    ----------
+    dct : dict[str, Num]
+        A dictionaly to be cleaned.
+    key_lst : list[str], optional
+        A list of keys. The default is DEFAULT_KEY.
 
-        key_lst (list[str]): A list of keys. 'DEFAULT_KEY' is used by default.
+    Raises
+    ------
+    ValueError
+        If a value in the input dictionary is not a bool, int, or float.
 
-    Returns:
-        dict[str, bool | set[Num]]: A cleaned dictionary containing only boolean or set values.
-
-    Raises:
-        ValueError: If a value in the input dictionary is not a bool, list, int, or float.
-
-    Examples:
-        >>> clean_values({'a': True, 'b': False, 'c': [1, 2, 3], 'd': 4.5, 'e': None})
-        {'a': True, 'c': {1, 2, 3}, 'd': {4.5}}
+    Returns
+    -------
+    dict[str, Num]
+        A cleaned dictionary containing only bool, int, or float values.
 
     """
-    assert isinstance(values, dict), "Values must be a dict"
-    ret_dict: dict[str, bool | set[Num]] = {}
+    assert isinstance(dct, dict), "Dct must be a dict"
+    ret_dct: dict[str, Num] = {}
 
-    keys = DEFAULT_KEY if key_lst is None else key_lst
-    for k in keys:
-        if k not in values:
+    for k in key_lst:
+        if k not in dct:
             continue
-        v = values[k]
+        v = dct[k]
         if v is None or v is False:
             continue
-        if isinstance(v, bool):
-            ret_dict[k] = v
-        elif isinstance(v, (list, set)):
-            ret_dict[k] = set(v)
-        elif isinstance(v, (int, float)):
-            ret_dict[k] = set([v])
+        if isinstance(v, int | float | bool):
+            ret_dct[k] = v
         else:
-            raise ValueError("Value must be a bool, set, list, int, or float")
+            raise ValueError(f"Value must be a bool, int, or float")
 
-    return ret_dict
+    return ret_dct
 
 
-def get_denominator(values: dict[str, bool | set[Num]]) -> int:
+def categorize_dict_keys(
+    results: list[dict[str, Num]] | dict[str, Num],
+    label_category: dict[str, list[str]],
+    vote_option: str = "union",
+) -> dict[str, set[str | Num]]:
     """
-    Calculates the denominator for a fraction based on the given dictionary of values.
+    Categorizes and aggregates dictionaries based on specified label categories and voting options.
 
-    Args:
-        values (dict[str, bool | set[Num]]): A dictionary of values where the keys are strings and the values are either boolean or sets of numbers.
+    Parameters
+    ----------
+    results : list[dict[str, Num]] | dict[str, Num]
+        A dictionary or a list of dictionaries containing key-value pairs to be categorized.
+    label_category : dict[str, list[str]]
+        A dictionary mapping category names to lists of keys that belong to each category.
+    vote_option : str, optional
+        The voting method to use for aggregation. Supported options are "union" and "majority_vote".
+        The default is "union".
 
-    Returns:
-        int: The denominator for the fraction, which is the sum of the number of values in each set and the number of boolean values.
+    Raises
+    ------
+    ValueError
+        If the provided `vote_option` is not a supported voting method.
 
-    Raises:
-        TypeError: If the input values are not in the expected format.
+    Returns
+    -------
+    aggregated_result : dict[str, set[str | Num]]
+        A dictionary where each key corresponds to a category name, and the corresponding value is a set containing
+        the aggregated values from the keys belonging to that category.
 
-    Example:
-        >>> get_denominator({'a': True, 'b': False, 'c': {'d', 'e', 'f'}})
-        5
     """
-    ret = 0
-    for v in values.values():
-        if isinstance(v, set):
-            ret += len(v)
-        else:
-            ret += 1
-    return ret
-
-
-def concat_json_result(
-    results: list[dict[str, Any]], vote_option: str = "union"
-) -> dict[str, set[Num] | bool]:
-    """
-    Merges a list of dictionaries into a single dictionary.
-
-    The function iterates over each dictionary in the input list. It cleans the values of each
-    dictionary using the `clean_values` function. Then, for each key-value pair in the cleaned
-    dictionary, if the key is not already in the merged dictionary, it adds the key-value pair.
-    If the key is already present, it performs a logical OR operation for boolean values, or a set
-    union operation for set values.
-
-    If a value is not a boolean or a set, it raises a TypeError.
-
-    The merged dictionary is cleaned with `clean_values` function at the end of each iteration.
-
-    Args:
-        results: A list of dictionaries. The dictionaries should contain keys of type str and
-                 values of type set of numbers (Num) or bool.
-        vote_option: Voting option. Supported values are 'union' and 'majority_vote'.
-
-    Returns:
-        A merged dictionary with keys of type str and values of type set of numbers (Num) or bool.
-    """
-    union_dict: dict[str, list[Num]] = {}
-    for result in results:
+    merged_result: defaultdict = defaultdict(list)
+    results_lst: list[dict[str, Num]] = (
+        [results] if isinstance(results, dict) else results
+    )
+    for result in results_lst:
         cleaned_result = clean_values(result)
 
-        for k, v in cleaned_result.items():
-            assert isinstance(v, bool | set)
-            union_dict.setdefault(k, [])
-            union_dict[k] += [v] if isinstance(v, bool) else list(v)
+        for category, subs in label_category.items():
+            is_single_category = True if len(subs) == 1 else False
+            for sub in subs:
+                if sub not in cleaned_result:
+                    continue
+                assert isinstance(cleaned_result[sub], int | float | bool)
+                if is_single_category:
+                    merged_result[category].append(cleaned_result[sub])
+                else:
+                    merged_result[category].append(sub)
 
-    merged_dict: dict[str, bool | set[Num]] = {}
+    aggregated_result: dict[str, set[str | Num]] = dict()
     match vote_option:
         case "union":
-            merged_dict = clean_values(union_dict)
+            aggregated_result = {k: set(v) for k, v in merged_result.items()}
         case "majority_vote":
-            for key, value in union_dict.items():
+            for key, value in merged_result.items():
                 cnt = Counter(value)
                 max_cnt = max(cnt.values())
                 majorities = [k for k, v in cnt.items() if v == max_cnt]
-                merged_dict[key] = set(majorities)
+                aggregated_result[key] = set(majorities)
         case _:
             raise ValueError(
                 f"'vote_option' must be a supported voting method, got '{vote_option}.'"
             )
-    for mkey, mvalue in merged_dict.items():  # TODO: Remove me
-        if isinstance(mvalue, bool):
-            continue
-        for vv in mvalue:
-            if vv is True:
-                merged_dict[mkey] = True
-                break
 
-    return merged_dict
+    return aggregated_result
+
+
+def uncategorize_dict_keys(
+    categorized_dct: dict[str, set[str | Num]],
+    label_category: dict[str, list[str]],
+) -> dict[str, bool | list[int | float]]:
+    """
+    Uncategorizes dictionary keys besed on specified label categories.
+
+    Parameters
+    ----------
+    categorized_dct : dict[str, set[str | Num]]
+        A dictionary containing categorized data where keys are category names and values are sets
+        containing elements of either string or numeric types.
+    label_category : dict[str, list[str]]
+       A dictionary mapping category names to lists of subcategory names. This helps determine whether
+       a category is a single subcategory or has multiple subcategories.
+
+    Returns
+    -------
+    uncategorized_dct : dict[str, bool | list[int | float]]
+        A dictionary with keys representing either categories or subcategories.
+
+    """
+    assert isinstance(categorized_dct, dict)
+    for i in categorized_dct.values():
+        assert isinstance(i, set)
+        for j in i:
+            assert isinstance(j, str | Num)
+
+    uncategorized_dct: dict[str, bool | list[int | float]] = dict()
+    for category, subs in label_category.items():
+        is_single_category = True if len(subs) == 1 else False
+        if category not in categorized_dct or not categorized_dct[category]:
+            continue
+        if is_single_category:
+            value = cast(set[Num], categorized_dct[category])
+            if len(value) == 1 and list(value)[0] is True:
+                uncategorized_dct[category] = True
+            else:
+                uncategorized_dct[category] = list(value)
+        else:
+            for sub in subs:
+                if sub in categorized_dct[category]:
+                    uncategorized_dct[sub] = True
+
+    return uncategorized_dct

--- a/tests/data/label_category.json
+++ b/tests/data/label_category.json
@@ -1,0 +1,101 @@
+{
+    "optim-optimizer": [
+        "optim-optimizer-Adadelta",
+        "optim-optimizer-Adagrad",
+        "optim-optimizer-Adam",
+        "optim-optimizer-AdamW",
+        "optim-optimizer-SparseAdam",
+        "optim-optimizer-Adamax",
+        "optim-optimizer-ASGD",
+        "optim-optimizer-LBFGS",
+        "optim-optimizer-NAdam",
+        "optim-optimizer-RAdam",
+        "optim-optimizer-RMSprop",
+        "optim-optimizer-Rprop",
+        "optim-optimizer-SGD",
+        "optim-optimizer-MomentumSGD"
+    ],
+    "optim-optimizer-momentum": [
+        "optim-optimizer-momentum"
+    ],
+    "optim-learningrate": [
+        "optim-learningrate"
+    ],
+    "optim-weightdecay": [
+        "optim-weightdecay"
+    ],
+    "optim-lrscheduler": [
+        "optim-lrscheduler-LambdaLR",
+        "optim-lrscheduler-MultiplicativeLR",
+        "optim-lrscheduler-StepLR",
+        "optim-lrscheduler-MultiStepLR",
+        "optim-lrscheduler-ConstantLR",
+        "optim-lrscheduler-LinearLR",
+        "optim-lrscheduler-ExponentialLR",
+        "optim-lrscheduler-PolynomialLR",
+        "optim-lrscheduler-CosineAnnealingLR",
+        "optim-lrscheduler-ChainedScheduler",
+        "optim-lrscheduler-SequentialLR",
+        "optim-lrscheduler-ReduceLROnPlateau",
+        "optim-lrscheduler-CyclicLR",
+        "optim-lrscheduler-OneCycleLR",
+        "optim-lrscheduler-CosineAnnealingWarmRestarts"
+    ],
+    "optim-earlystopping": [
+        "optim-earlystopping"
+    ],
+    "batchsize": [
+        "batchsize"
+    ],
+    "iterations": [
+        "iterations"
+    ],
+    "epochs": [
+        "epochs"
+    ],
+    "FPS": [
+        "FPS"
+    ],
+    "runtime-train": [
+        "runtime-train"
+    ],
+    "runtime-inference": [
+        "runtime-inference"
+    ],
+    "resource-train-gpu": [
+        "resource-train-gpu-V100",
+        "resource-train-gpu-T4",
+        "resource-train-gpu-P100",
+        "resource-train-gpu-A100",
+        "resource-train-gpu-M40",
+        "resource-train-tpu-v3",
+        "resource-train-tpu-v4",
+        "resource-train-gpu-GTX1660Ti",
+        "resource-train-gpu-RTX2070",
+        "resource-train-gpu-RTX3080"
+    ],
+    "resource-train-gpu-num": [
+        "resource-train-gpu-num"
+    ],
+    "resource-train-gpu-memory": [
+        "resource-train-gpu-memory"
+    ],
+    "resource-inference-gpu": [
+        "resource-inference-gpu-V100",
+        "resource-inference-gpu-T4",
+        "resource-inference-gpu-P100",
+        "resource-inference-gpu-A100",
+        "resource-inference-gpu-M40",
+        "resource-inference-tpu-v3",
+        "resource-inference-tpu-v4",
+        "resource-inference-gpu-GTX1660Ti",
+        "resource-inference-gpu-RTX2070",
+        "resource-inference-gpu-RTX3080"
+    ],
+    "resource-inference-gpu-num": [
+        "resource-inference-gpu-num"
+    ],
+    "resource-inference-gpu-memory": [
+        "resource-inference-gpu-memory"
+    ]
+}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append("../gptsenpy")
 
 from gptsenpy.io.read import read_json
-from gptsenpy.metrics import Metrics
+from gptsenpy.metrics import MetricGroup
 from gptsenpy.utils import categorize_dict_keys
 
 
@@ -15,17 +15,20 @@ with open("tests/data/label_category.json", "r") as f:
 def test_Metrics_0():
     data_path = "tests/data/annotation_format.json"
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
-    assert data == {}
 
-    recalls, precisions = [], []
-    num_labels, num_preds = [], []
-    for _ in range(len(LABEL_CATEGORY)):
-        mt = Metrics(set(), set())
-        recalls.append(mt.recall)
-        precisions.append(mt.precision)
-        num_labels.append(mt.num_labels)
-        num_preds.append(mt.num_preds)
-    assert recalls == precisions == num_labels == num_preds == [0] * len(LABEL_CATEGORY)
+    mt = MetricGroup(data, data, LABEL_CATEGORY)
+    assert mt.recall == mt.precision == 0
+    assert mt.num_labels == mt.num_preds == 0
+    assert (
+        mt.recall_lst
+        == mt.precision_lst
+        == mt.num_labels_lst
+        == mt.num_preds_lst
+        == [0] * len(LABEL_CATEGORY)
+    )
+
+    expected = {"recall": 0, "precision": 0, "num_labels": 0, "num_preds": 0}
+    assert mt.export_metrics() == expected
 
 
 def test_Metrics_1():
@@ -33,37 +36,23 @@ def test_Metrics_1():
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
-    expected = {
-        "optim-optimizer": {"optim-optimizer-MomentumSGD"},
-        "optim-optimizer-momentum": {0.9},
-        "optim-learningrate": {0.4},
-        "optim-weightdecay": {0.0005},
-        "optim-lrscheduler": {"optim-lrscheduler-CosineAnnealingLR"},
-        "batchsize": {256},
-        "epochs": {300},
-        "resource-train-gpu": {"resource-train-gpu-T4"},
-        "resource-inference-gpu": {"resource-inference-gpu-T4"},
-    }
-    assert data == expected
 
-    recalls, precisions = [], []
-    num_labels, num_preds = [], []
-    for i in LABEL_CATEGORY:
-        gt = data[i] if i in data else set()
-        pred = data[i] if i in data else set()
-        mt = Metrics(gt, pred)
-        recalls.append(mt.recall)
-        precisions.append(mt.precision)
-        num_labels.append(mt.num_labels)
-        num_preds.append(mt.num_preds)
+    mt = MetricGroup(data, data, LABEL_CATEGORY)
+    assert mt.recall == mt.precision == 9 / 18
+    assert mt.num_labels == mt.num_preds == 9
     assert (
-        num_labels
-        == num_preds
+        mt.recall_lst
+        == mt.precision_lst
         == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
     )
     assert (
-        recalls == precisions == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+        mt.num_labels_lst
+        == mt.num_preds_lst
+        == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
     )
+
+    expected = {"recall": 9 / 18, "precision": 9 / 18, "num_labels": 9, "num_preds": 9}
+    assert mt.export_metrics() == expected
 
 
 def test_Metrics_2():
@@ -72,17 +61,20 @@ def test_Metrics_2():
     )
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
 
-    recalls, precisions = [], []
-    num_labels, num_preds = [], []
-    for i in LABEL_CATEGORY:
-        gt = data[i] if i in data else set()
-        mt = Metrics(gt, set())
-        recalls.append(mt.recall)
-        precisions.append(mt.precision)
-        num_labels.append(mt.num_labels)
-        num_preds.append(mt.num_preds)
-    assert recalls == precisions == num_preds == [0] * len(LABEL_CATEGORY)
-    assert num_labels == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+    mt = MetricGroup(data, {}, LABEL_CATEGORY)
+    assert mt.recall == mt.precision == 0
+    assert mt.num_labels == 9
+    assert mt.num_preds == 0
+    assert (
+        mt.recall_lst
+        == mt.precision_lst
+        == mt.num_preds_lst
+        == [0] * len(LABEL_CATEGORY)
+    )
+    assert mt.num_labels_lst == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+
+    expected = {"recall": 0, "precision": 0, "num_labels": 9, "num_preds": 0}
+    assert mt.export_metrics() == expected
 
 
 def test_Metrics_3():
@@ -91,17 +83,20 @@ def test_Metrics_3():
     )
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
 
-    recalls, precisions = [], []
-    num_labels, num_preds = [], []
-    for i in LABEL_CATEGORY:
-        pred = data[i] if i in data else set()
-        mt = Metrics(set(), pred)
-        recalls.append(mt.recall)
-        precisions.append(mt.precision)
-        num_labels.append(mt.num_labels)
-        num_preds.append(mt.num_preds)
-    assert recalls == precisions == num_labels == [0] * len(LABEL_CATEGORY)
-    assert num_preds == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+    mt = MetricGroup({}, data, LABEL_CATEGORY)
+    assert mt.recall == mt.precision == 0
+    assert mt.num_labels == 0
+    assert mt.num_preds == 9
+    assert (
+        mt.recall_lst
+        == mt.precision_lst
+        == mt.num_labels_lst
+        == [0] * len(LABEL_CATEGORY)
+    )
+    assert mt.num_preds_lst == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+
+    expected = {"recall": 0, "precision": 0, "num_labels": 0, "num_preds": 9}
+    assert mt.export_metrics() == expected
 
 
 def test_Metrics_4():
@@ -124,17 +119,12 @@ def test_Metrics_4():
         "epochs": {10, 20, 30},
     }
 
-    recalls, precisions = [], []
-    num_labels, num_preds = [], []
-    for i in LABEL_CATEGORY:
-        gt = gts[i] if i in gts else set()
-        pred = preds[i] if i in preds else set()
-        mt = Metrics(gt, pred)
-        recalls.append(mt.recall)
-        precisions.append(mt.precision)
-        num_labels.append(mt.num_labels)
-        num_preds.append(mt.num_preds)
-    assert recalls == [
+    mt = MetricGroup(gts, preds, LABEL_CATEGORY)
+    assert mt.recall == 4 / 18
+    assert mt.precision == (2 + 1 / 3) / 18
+    assert mt.num_labels == 6
+    assert mt.num_preds == 10
+    assert mt.recall_lst == [
         1 / 1,
         0,
         0,
@@ -154,7 +144,7 @@ def test_Metrics_4():
         0,
         0,
     ]
-    assert precisions == [
+    assert mt.precision_lst == [
         1 / 2,
         0,
         0,
@@ -174,5 +164,13 @@ def test_Metrics_4():
         0,
         0,
     ]
-    assert num_labels == [1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    assert num_preds == [2, 0, 0, 2, 2, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    assert mt.num_labels_lst == [1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    assert mt.num_preds_lst == [2, 0, 0, 2, 2, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+    expected = {
+        "recall": 4 / 18,
+        "precision": (2 + 1 / 3) / 18,
+        "num_labels": 6,
+        "num_preds": 10,
+    }
+    assert mt.export_metrics() == expected

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,23 +12,39 @@ with open("tests/data/label_category.json", "r") as f:
     LABEL_CATEGORY = json.load(f)
 
 
+def calc_f1(recall, precision):
+    if recall + precision:
+        return 2 * (recall * precision) / (recall + precision)
+    else:
+        return 0
+
+
 def test_Metrics_0():
     data_path = "tests/data/annotation_format.json"
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup(data, data, LABEL_CATEGORY)
-    assert mt.recall == mt.precision == 0
+
+    expected_metrics = {i: 0 for i in LABEL_CATEGORY}
+    expected_export = {
+        "recall": 0,
+        "precision": 0,
+        "f1": 0,
+        "num_labels": 0,
+        "num_preds": 0,
+    }
+
+    assert mt.recall == mt.precision == mt.f1 == 0
     assert mt.num_labels == mt.num_preds == 0
     assert (
-        mt.recall_lst
-        == mt.precision_lst
-        == mt.num_labels_lst
-        == mt.num_preds_lst
-        == [0] * len(LABEL_CATEGORY)
+        mt.recall_dct
+        == mt.precision_dct
+        == mt.f1_dct
+        == mt.num_labels_dct
+        == mt.num_preds_dct
+        == expected_metrics
     )
-
-    expected = {"recall": 0, "precision": 0, "num_labels": 0, "num_preds": 0}
-    assert mt.export_metrics() == expected
+    assert mt.export_metrics() == expected_export
 
 
 def test_Metrics_1():
@@ -38,21 +54,38 @@ def test_Metrics_1():
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup(data, data, LABEL_CATEGORY)
-    assert mt.recall == mt.precision == 9 / 18
-    assert mt.num_labels == mt.num_preds == 9
-    assert (
-        mt.recall_lst
-        == mt.precision_lst
-        == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
-    )
-    assert (
-        mt.num_labels_lst
-        == mt.num_preds_lst
-        == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
-    )
 
-    expected = {"recall": 9 / 18, "precision": 9 / 18, "num_labels": 9, "num_preds": 9}
-    assert mt.export_metrics() == expected
+    expected_recall_precision = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY, [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+        )
+    }
+    expected_f1_dct = {
+        i: calc_f1(j, j)
+        for i, j in zip(LABEL_CATEGORY, expected_recall_precision.values())
+    }
+    expected_num = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY, [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+        )
+    }
+    expected_export = {
+        "recall": 9 / 18,
+        "precision": 9 / 18,
+        "f1": sum(expected_f1_dct.values()) / len(expected_f1_dct.values()),
+        "num_labels": 9,
+        "num_preds": 9,
+    }
+
+    assert mt.recall == mt.precision == 9 / 18
+    assert mt.f1 == sum(expected_f1_dct.values()) / len(expected_f1_dct.values())
+    assert mt.num_labels == mt.num_preds == 9
+    assert mt.recall_dct == mt.precision_dct == expected_recall_precision
+    assert mt.f1_dct == expected_f1_dct
+    assert mt.num_labels_dct == mt.num_preds_dct == expected_num
+    assert mt.export_metrics() == expected_export
 
 
 def test_Metrics_2():
@@ -62,19 +95,34 @@ def test_Metrics_2():
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup(data, {}, LABEL_CATEGORY)
-    assert mt.recall == mt.precision == 0
+
+    expected_metrics = {i: 0 for i in LABEL_CATEGORY}
+    expected_num_labels_dct = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY, [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+        )
+    }
+    expected_export = {
+        "recall": 0,
+        "precision": 0,
+        "f1": 0,
+        "num_labels": 9,
+        "num_preds": 0,
+    }
+
+    assert mt.recall == mt.precision == mt.f1 == 0
     assert mt.num_labels == 9
     assert mt.num_preds == 0
     assert (
-        mt.recall_lst
-        == mt.precision_lst
-        == mt.num_preds_lst
-        == [0] * len(LABEL_CATEGORY)
+        mt.recall_dct
+        == mt.precision_dct
+        == mt.f1_dct
+        == mt.num_preds_dct
+        == expected_metrics
     )
-    assert mt.num_labels_lst == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
-
-    expected = {"recall": 0, "precision": 0, "num_labels": 9, "num_preds": 0}
-    assert mt.export_metrics() == expected
+    assert mt.num_labels_dct == expected_num_labels_dct
+    assert mt.export_metrics() == expected_export
 
 
 def test_Metrics_3():
@@ -84,19 +132,34 @@ def test_Metrics_3():
     data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup({}, data, LABEL_CATEGORY)
-    assert mt.recall == mt.precision == 0
+
+    expected_metrics = {i: 0 for i in LABEL_CATEGORY}
+    expected_num_preds_dct = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY, [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+        )
+    }
+    expected_export = {
+        "recall": 0,
+        "precision": 0,
+        "f1": 0,
+        "num_labels": 0,
+        "num_preds": 9,
+    }
+
+    assert mt.recall == mt.precision == mt.f1 == 0
     assert mt.num_labels == 0
     assert mt.num_preds == 9
     assert (
-        mt.recall_lst
-        == mt.precision_lst
-        == mt.num_labels_lst
-        == [0] * len(LABEL_CATEGORY)
+        mt.recall_dct
+        == mt.precision_dct
+        == mt.f1_dct
+        == mt.num_labels_dct
+        == expected_metrics
     )
-    assert mt.num_preds_lst == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
-
-    expected = {"recall": 0, "precision": 0, "num_labels": 0, "num_preds": 9}
-    assert mt.export_metrics() == expected
+    assert mt.num_preds_dct == expected_num_preds_dct
+    assert mt.export_metrics() == expected_export
 
 
 def test_Metrics_4():
@@ -120,57 +183,86 @@ def test_Metrics_4():
     }
 
     mt = MetricGroup(gts, preds, LABEL_CATEGORY)
-    assert mt.recall == 4 / 18
-    assert mt.precision == (2 + 1 / 3) / 18
-    assert mt.num_labels == 6
-    assert mt.num_preds == 10
-    assert mt.recall_lst == [
-        1 / 1,
-        0,
-        0,
-        0,
-        1 / 1,
-        0,
-        0,
-        1 / 1,
-        1 / 1,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ]
-    assert mt.precision_lst == [
-        1 / 2,
-        0,
-        0,
-        0 / 2,
-        1 / 2,
-        0,
-        0,
-        1 / 1,
-        1 / 3,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ]
-    assert mt.num_labels_lst == [1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    assert mt.num_preds_lst == [2, 0, 0, 2, 2, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
-    expected = {
+    expected_recall_dct = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY,
+            [1 / 1, 0, 0, 0, 1 / 1, 0, 0, 1 / 1, 1 / 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        )
+    }
+    expected_precision_dct = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY,
+            [1 / 2, 0, 0, 0 / 2, 1 / 2, 0, 0, 1 / 1, 1 / 3, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        )
+    }
+    expected_f1_dct = {
+        i: calc_f1(j, k)
+        for i, j, k in zip(
+            LABEL_CATEGORY,
+            expected_recall_dct.values(),
+            expected_precision_dct.values(),
+        )
+    }
+    expected_num_labels_dct = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY, [1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
+    }
+    expected_num_preds_dct = {
+        i: j
+        for i, j in zip(
+            LABEL_CATEGORY, [2, 0, 0, 2, 2, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
+    }
+    expected_export = {
         "recall": 4 / 18,
         "precision": (2 + 1 / 3) / 18,
+        "f1": sum(expected_f1_dct.values()) / len(expected_f1_dct.values()),
         "num_labels": 6,
         "num_preds": 10,
     }
-    assert mt.export_metrics() == expected
+
+    assert mt.recall == 4 / 18
+    assert mt.precision == (2 + 1 / 3) / 18
+    assert mt.f1 == sum(expected_f1_dct.values()) / len(expected_f1_dct.values())
+    assert mt.num_labels == 6
+    assert mt.num_preds == 10
+    assert mt.recall_dct == expected_recall_dct
+    assert mt.precision_dct == expected_precision_dct
+    assert mt.f1_dct == expected_f1_dct
+    assert mt.num_labels_dct == expected_num_labels_dct
+    assert mt.num_preds_dct == expected_num_preds_dct
+    assert mt.export_metrics() == expected_export
+
+
+def test_Metrics_5():
+    data_path = (
+        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
+    )
+    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+
+    mt = MetricGroup(data, data, [])
+
+    expected_export = {
+        "recall": 0,
+        "precision": 0,
+        "f1": 0,
+        "num_labels": 0,
+        "num_preds": 0,
+    }
+
+    assert mt.recall == mt.precision == mt.f1 == 0
+    assert mt.num_labels == mt.num_preds == 0
+    assert (
+        mt.recall_dct
+        == mt.precision_dct
+        == mt.f1_dct
+        == mt.num_labels_dct
+        == mt.num_preds_dct
+        == {}
+    )
+    assert mt.export_metrics() == expected_export

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,350 +1,178 @@
+import json
 import sys
 
 sys.path.append("../gptsenpy")
 
 from gptsenpy.io.read import read_json
 from gptsenpy.metrics import Metrics
-from gptsenpy.utils import clean_values
+from gptsenpy.utils import categorize_dict_keys
 
 
-def test_precision_recall_0():
+with open("tests/data/label_category.json", "r") as f:
+    LABEL_CATEGORY = json.load(f)
+
+
+def test_Metrics_0():
     data_path = "tests/data/annotation_format.json"
-    data = read_json(data_path)
-    mt = Metrics(data, data)
-    assert mt.num_labels == mt.num_preds == 0
-    assert mt.precision == 0.0 and mt.recall == 0.0
-    score_dict = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
-    assert mt.export_metrics() == score_dict
+    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+    assert data == {}
+
+    recalls, precisions = [], []
+    num_labels, num_preds = [], []
+    for _ in range(len(LABEL_CATEGORY)):
+        mt = Metrics(set(), set())
+        recalls.append(mt.recall)
+        precisions.append(mt.precision)
+        num_labels.append(mt.num_labels)
+        num_preds.append(mt.num_preds)
+    assert recalls == precisions == num_labels == num_preds == [0] * len(LABEL_CATEGORY)
 
 
-def test_precision_recall_1():
+def test_Metrics_1():
     data_path = (
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
-    data = read_json(data_path)
-    mt = Metrics(data, data)
-    assert mt.num_labels == mt.num_preds == 9
-    assert mt.precision == 1.0 and mt.recall == 1.0
-    score_dict = {"precision": 1.0, "recall": 1.0, "f1": 1.0}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_2():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    mt = Metrics(data, {})
-    assert mt.num_labels == 9
-    assert mt.num_preds == 0
-    assert mt.precision == 0.0 and mt.recall == 0.0
-    score_dict = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_3():
-    data_path = "tests/data/annotation_format.json"
-    data = read_json(data_path)
-    mt = Metrics(data, {})
-    assert mt.num_labels == mt.num_preds == 0
-    assert mt.precision == 0.0 and mt.recall == 0.0
-    score_dict = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_4():
-    data_path = "tests/data/annotation_format.json"
-    data = read_json(data_path)
-    true_dct = {
-        "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0001,
-        "optim-lrscheduler-LambdaLR": True,
-        "batchsize": 256,
-        "epochs": 300,
-        "resource-train-gpu-T4": True,
+    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+    expected = {
+        "optim-optimizer": {"optim-optimizer-MomentumSGD"},
+        "optim-optimizer-momentum": {0.9},
+        "optim-learningrate": {0.4},
+        "optim-weightdecay": {0.0005},
+        "optim-lrscheduler": {"optim-lrscheduler-CosineAnnealingLR"},
+        "batchsize": {256},
+        "epochs": {300},
+        "resource-train-gpu": {"resource-train-gpu-T4"},
+        "resource-inference-gpu": {"resource-inference-gpu-T4"},
     }
-    mt = Metrics(data, true_dct)
-    assert mt.num_labels == 0
-    assert mt.num_preds == 8
-    assert mt.precision == 0.0 and mt.recall == 0.0
-    score_dict = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
-    assert mt.export_metrics() == score_dict
+    assert data == expected
+
+    recalls, precisions = [], []
+    num_labels, num_preds = [], []
+    for i in LABEL_CATEGORY:
+        gt = data[i] if i in data else set()
+        pred = data[i] if i in data else set()
+        mt = Metrics(gt, pred)
+        recalls.append(mt.recall)
+        precisions.append(mt.precision)
+        num_labels.append(mt.num_labels)
+        num_preds.append(mt.num_preds)
+    assert (
+        num_labels
+        == num_preds
+        == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+    )
+    assert (
+        recalls == precisions == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+    )
 
 
-def test_precision_recall_7():
-    data_path = "tests/data/annotation_format.json"
-    data = read_json(data_path)
-    true_dct = {
-        "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0001,
-        "optim-lrscheduler-LambdaLR": True,
-        "batchsize": 256,
-        "epochs": 300,
-        "resource-train-gpu-T4": True,
-    }
-    mt = Metrics(true_dct, data)
-    assert mt.num_labels == 8
-    assert mt.num_preds == 0
-    assert mt.precision == 0.0 and mt.recall == 0.0
-    score_dict = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_5():
+def test_Metrics_2():
     data_path = (
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
-    data = read_json(data_path)
+    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+
+    recalls, precisions = [], []
+    num_labels, num_preds = [], []
+    for i in LABEL_CATEGORY:
+        gt = data[i] if i in data else set()
+        mt = Metrics(gt, set())
+        recalls.append(mt.recall)
+        precisions.append(mt.precision)
+        num_labels.append(mt.num_labels)
+        num_preds.append(mt.num_preds)
+    assert recalls == precisions == num_preds == [0] * len(LABEL_CATEGORY)
+    assert num_labels == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+
+
+def test_Metrics_3():
+    data_path = (
+        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
+    )
+    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+
+    recalls, precisions = [], []
+    num_labels, num_preds = [], []
+    for i in LABEL_CATEGORY:
+        pred = data[i] if i in data else set()
+        mt = Metrics(set(), pred)
+        recalls.append(mt.recall)
+        precisions.append(mt.precision)
+        num_labels.append(mt.num_labels)
+        num_preds.append(mt.num_preds)
+    assert recalls == precisions == num_labels == [0] * len(LABEL_CATEGORY)
+    assert num_preds == [1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0]
+
+
+def test_Metrics_4():
+    gts = {
+        "optim-optimizer": {"optim-optimizer-Adam"},
+        "optim-lrscheduler": {"optim-lrscheduler-CosineAnnealingLR"},
+        "optim-earlystopping": {True},
+        "batchsize": {16},
+        "iterations": {5510},
+        "epochs": {10},
+    }
     preds = {
-        "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
+        "optim-optimizer": {"optim-optimizer-Adam", "optim-optimizer-SGD"},
+        "optim-weightdecay": {5e-5, 5e-4},
+        "optim-lrscheduler": {
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        },
+        "iterations": {5510},
+        "epochs": {10, 20, 30},
     }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 9
-    assert mt.precision == 8 / 9 and mt.recall == 8 / 9
-    f1 = 2 * (8 / 9) * (8 / 9) / (8 / 9 + 8 / 9)
-    score_dict = {"precision": 8 / 9, "recall": 8 / 9, "f1": f1}
-    assert mt.export_metrics() == score_dict
 
-
-def test_precision_recall_6():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        # "optim-optimizer-MomentumSGD": True,
-        # "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 7
-    assert mt.precision == 6 / 7
-    assert mt.recall == 6 / 9
-    f1 = 2 * (6 / 7) * (6 / 9) / (6 / 7 + 6 / 9)
-    score_dict = {"precision": 6 / 7, "recall": 6 / 9, "f1": f1}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_9():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        # "optim-optimizer-MomentumSGD": True,
-        # "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 7
-    assert mt.get_precision(data, preds) == 6 / 7
-    assert mt.get_recall(data, preds) == 6 / 9
-    assert mt.precision == 6 / 7
-    assert mt.recall == 6 / 9
-
-
-def test_precision_recall_8():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        # "optim-optimizer-MomentumSGD": True,
-        # "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 7
-    assert mt.get_precision(data, {}) == 0
-    assert mt.get_recall({}, preds) == 0
-    assert mt.precision == 6 / 7
-    assert mt.recall == 6 / 9
-
-
-def test_precision_recall_10():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        # "optim-optimizer-MomentumSGD": True,
-        # "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 7
-    assert mt.get_precision(data, data) == 1.0
-    assert mt.get_recall(preds, preds) == 1.0
-    assert mt.precision == 6 / 7
-    assert mt.recall == 6 / 9
-
-
-def test_precision_recall_11():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        # "optim-optimizer-MomentumSGD": True,
-        # "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": 0.4,
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 6
-    assert mt.precision == 5 / 6
-    assert mt.recall == 5 / 9
-    f1 = 2 * (5 / 6) * (5 / 9) / (5 / 6 + 5 / 9)
-    score_dict = {"precision": 5 / 6, "recall": 5 / 9, "f1": f1}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_12():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        # "optim-optimizer-MomentumSGD": True,
-        # "optim-optimizer-momentum": 0.9,
-        "optim-learningrate": [0.4, 0.7],
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 8
-    assert mt.precision == 6 / 8
-    assert mt.recall == 6 / 9
-    f1 = 2 * (6 / 8) * (6 / 9) / (6 / 8 + 6 / 9)
-    score_dict = {"precision": 6 / 8, "recall": 6 / 9, "f1": f1}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_13():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": [0.9, 0.9],
-        "optim-learningrate": [0.4, 0.9],
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 10
-    assert mt.precision == 8 / 10
-    assert mt.recall == 8 / 9
-    f1 = 2 * (8 / 10) * (8 / 9) / (8 / 10 + 8 / 9)
-    score_dict = {"precision": 8 / 10, "recall": 8 / 9, "f1": f1}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_14():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": [0.9, 0.9],
-        "optim-learningrate": [4e-01],
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 9
-    assert mt.precision == 8 / 9
-    assert mt.recall == 8 / 9
-    f1 = 2 * (8 / 9) * (8 / 9) / (8 / 9 + 8 / 9)
-    score_dict = {"precision": 8 / 9, "recall": 8 / 9, "f1": f1}
-    assert mt.export_metrics() == score_dict
-
-
-def test_precision_recall_15():
-    data_path = (
-        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
-    )
-    data = read_json(data_path)
-    preds = {
-        "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": [9000e-4, 0.9],
-        "optim-learningrate": [4e-01],
-        "optim-weightdecay": 0.0005,
-        "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": 256,
-        "epochs": 200,  # 300 -> 200
-        "resource-train-gpu-T4": True,
-        "resource-inference-gpu-T4": True,
-    }
-    mt = Metrics(data, preds)
-    assert mt.num_labels == 9
-    assert mt.num_preds == 9
-    assert mt.precision == 8 / 9
-    assert mt.recall == 8 / 9
-    f1 = 2 * (8 / 9) * (8 / 9) / (8 / 9 + 8 / 9)
-    score_dict = {"precision": 8 / 9, "recall": 8 / 9, "f1": f1}
-    assert mt.export_metrics() == score_dict
+    recalls, precisions = [], []
+    num_labels, num_preds = [], []
+    for i in LABEL_CATEGORY:
+        gt = gts[i] if i in gts else set()
+        pred = preds[i] if i in preds else set()
+        mt = Metrics(gt, pred)
+        recalls.append(mt.recall)
+        precisions.append(mt.precision)
+        num_labels.append(mt.num_labels)
+        num_preds.append(mt.num_preds)
+    assert recalls == [
+        1 / 1,
+        0,
+        0,
+        0,
+        1 / 1,
+        0,
+        0,
+        1 / 1,
+        1 / 1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
+    assert precisions == [
+        1 / 2,
+        0,
+        0,
+        0 / 2,
+        1 / 2,
+        0,
+        0,
+        1 / 1,
+        1 / 3,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
+    assert num_labels == [1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    assert num_preds == [2, 0, 0, 2, 2, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,18 +1,13 @@
+import json
 import sys
 
 sys.path.append("../gptsenpy")
 from gptsenpy.io.read import read_json
-from gptsenpy.utils import clean_values, concat_json_result, get_denominator
+from gptsenpy.utils import clean_values, categorize_dict_keys, uncategorize_dict_keys
 
 
-def test_get_denominator_0():
-    dct = {}
-    assert get_denominator(dct) == 0
-
-
-def test_get_denominator_1():
-    dct = {"a": True, "b": False, "c": {"d", "e", "f"}}
-    assert get_denominator(dct) == 5
+with open("tests/data/label_category.json", "r") as f:
+    label_category = json.load(f)
 
 
 def test_clean_values_null():
@@ -26,7 +21,7 @@ def test_clean_values_1():
     data_path = "tests/data/Attention_Augmented_Convolutional_Networks.json"
     data = read_json(data_path)
     assert type(data) == dict
-    assert clean_values(data) == {"epochs": {150}}
+    assert clean_values(data) == {"epochs": 150}
 
 
 def test_clean_values_2():
@@ -37,12 +32,12 @@ def test_clean_values_2():
     assert type(data) == dict
     true_dct = {
         "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": {0.9},
-        "optim-learningrate": {0.4},
-        "optim-weightdecay": {0.0005},
+        "optim-optimizer-momentum": 0.9,
+        "optim-learningrate": 0.4,
+        "optim-weightdecay": 0.0005,
         "optim-lrscheduler-CosineAnnealingLR": True,
-        "batchsize": {256},
-        "epochs": {300},
+        "batchsize": 256,
+        "epochs": 300,
         "resource-train-gpu-T4": True,
         "resource-inference-gpu-T4": True,
     }
@@ -62,7 +57,7 @@ def test_clean_values_3():
     ]
     true_dct = {
         "optim-optimizer-MomentumSGD": True,
-        "optim-optimizer-momentum": {0.9},
+        "optim-optimizer-momentum": 0.9,
     }
     assert clean_values(data, key_lst) == true_dct
 
@@ -81,169 +76,222 @@ def test_clean_values_4():
     assert clean_values(data, key_lst) == true_dct
 
 
-def test_concat_json_0():
+def test_categorize_dict_keys_0():
     dct1 = {
-        "epochs": 0,
         "optim-optimizer-Adam": True,
-        "optim-lrscheduler-CosineAnnealingLR": False,
+        "optim-lrscheduler-LambdaLR": True,
         "optim-weightdecay": 5e-5,
+        "epochs": 10,
     }
     dct2 = {
-        "epochs": 1,
         "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 5e-5,
-    }
-    dct3 = {
-        "epochs": 1,
-        "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 5e-5,
-        "iterations": 5510,
-    }
-    expected = {
-        "epochs": {0, 1},
-        "optim-optimizer-Adam": True,
-        "optim-weightdecay": {5e-5},
-        "iterations": {5510},
-    }
-    expected_majority_vote = {
-        "epochs": {1},
-        "optim-optimizer-Adam": True,
-        "optim-weightdecay": {5e-5},
-        "iterations": {5510},
-    }
-    assert concat_json_result([dct1, dct2, dct3]) == expected
-    assert (
-        concat_json_result([dct1, dct2, dct3], vote_option="majority_vote")
-        == expected_majority_vote
-    )
-
-
-def test_concat_json_1():
-    dct1 = {
-        "epochs": 0,
-        "optim-optimizer-Adam": True,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 5e-5,
-    }
-    dct2 = {
-        "epochs": 1,
-        "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 5e-5,
-    }
-    dct3 = {
-        "epochs": 1,
-        "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
+        "optim-lrscheduler-CosineAnnealingLR": True,
         "optim-weightdecay": 0.00005,
-        "iterations": 5510,
-    }
-    expected = {
-        "epochs": {0, 1},
-        "optim-optimizer-Adam": True,
-        "optim-weightdecay": {5e-5},
-        "iterations": {5510},
-    }
-    expected_majority_vote = {
-        "epochs": {1},
-        "optim-optimizer-Adam": True,
-        "optim-weightdecay": {5e-5},
-        "iterations": {5510},
-    }
-
-    assert concat_json_result([dct1, dct2, dct3]) == expected
-    assert (
-        concat_json_result([dct1, dct2, dct3], vote_option="majority_vote")
-        == expected_majority_vote
-    )
-
-
-def test_concat_json_2():
-    dct1 = {
-        "epochs": 0,
-        "optim-optimizer-Adam": True,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 5e-5,
-    }
-    dct2 = {
-        "epochs": 1,
-        "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 5e-5,
+        "epochs": 20,
     }
     dct3 = {
-        "epochs": 1,
-        "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 0.00005,
+        "optim-optimizer-SGD": True,
+        "optim-lrscheduler-CosineAnnealingLR": True,
+        "optim-weightdecay": 5e-4,
+        "epochs": 20,
         "iterations": 5510,
     }
-    dct4 = {
-        "epochs": 1,
-        "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 0.00005,
-        "FPS": 1e5,
+    label_category = {
+        "optim-optimizer": ["optim-optimizer-Adam", "optim-optimizer-SGD"],
+        "optim-lrscheduler": [
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        ],
+        "optim-weightdecay": ["optim-weightdecay"],
+        "epochs": ["epochs"],
+        "iterations": ["iterations"],
     }
     expected = {
-        "epochs": {0, 1},
-        "optim-optimizer-Adam": True,
-        "optim-weightdecay": {5e-5},
+        "optim-optimizer": {"optim-optimizer-Adam", "optim-optimizer-SGD"},
+        "optim-lrscheduler": {
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        },
+        "optim-weightdecay": {5e-5, 5e-4},
+        "epochs": {10, 20},
         "iterations": {5510},
-        "FPS": {100000},
     }
     expected_majority_vote = {
-        "epochs": {1},
-        "optim-optimizer-Adam": True,
+        "optim-optimizer": {"optim-optimizer-Adam", "optim-optimizer-SGD"},
+        "optim-lrscheduler": {"optim-lrscheduler-CosineAnnealingLR"},
         "optim-weightdecay": {5e-5},
+        "epochs": {20},
         "iterations": {5510},
-        "FPS": {100000},
     }
-    assert concat_json_result([dct1, dct2, dct3, dct4]) == expected
+    assert categorize_dict_keys([dct1, dct2, dct3], label_category) == expected
     assert (
-        concat_json_result([dct1, dct2, dct3, dct4], vote_option="majority_vote")
+        categorize_dict_keys([dct1, dct2, dct3], label_category, "majority_vote")
         == expected_majority_vote
     )
 
 
-def test_concat_json_3():
+def test_categorize_dict_keys_1():
     dct1 = {
-        "epochs": 0,
-        "optim-optimizer-Adam": True,
-        "optim-lrscheduler-CosineAnnealingLR": False,
+        "optim-optimizer-Adam": False,
+        "optim-lrscheduler-LambdaLR": True,
         "optim-weightdecay": 5e-5,
+        "optim-earlystopping": True,
+        "epochs": 10,
     }
     dct2 = {
-        "epochs": 0,
         "optim-optimizer-Adam": False,
-        "optim-lrscheduler-CosineAnnealingLR": False,
-        "optim-weightdecay": 5e-5,
+        "optim-lrscheduler-CosineAnnealingLR": True,
+        "optim-weightdecay": 5e-4,
+        "optim-earlystopping": False,
+        "epochs": 20,
     }
     dct3 = {
-        "epochs": 1,
-        "optim-weightdecay": 4e-5,
-        "iterations": 5510,
+        "optim-optimizer-not_exist": True,
+        "optim-lrscheduler-CosineAnnealingLR": False,
+        "optim-weightdecay": 5e-3,
     }
-    dct4 = {
-        "epochs": 1,
-        "iterations": 100,
+    label_category = {
+        "optim-optimizer": ["optim-optimizer-Adam", "optim-optimizer-SGD"],
+        "optim-lrscheduler": [
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        ],
+        "optim-weightdecay": ["optim-weightdecay"],
+        "optim-earlystopping": ["optim-earlystopping"],
+        "epochs": ["epochs"],
+        "iterations": ["iterations"],  # not include in any of dct1, dct2, and dct3
     }
     expected = {
-        "epochs": {0, 1},
-        "optim-optimizer-Adam": True,
-        "optim-weightdecay": {5e-5, 4e-5},
-        "iterations": {5510, 100},
+        "optim-lrscheduler": {
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        },
+        "optim-weightdecay": {5e-5, 5e-4, 5e-3},
+        "optim-earlystopping": {True},
+        "epochs": {10, 20},
     }
     expected_majority_vote = {
-        "epochs": {0, 1},
-        "optim-optimizer-Adam": True,
-        "optim-weightdecay": {5e-5},
-        "iterations": {5510, 100},
+        "optim-lrscheduler": {
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        },
+        "optim-weightdecay": {5e-5, 5e-4, 5e-3},
+        "optim-earlystopping": {True},
+        "epochs": {10, 20},
     }
-    assert concat_json_result([dct1, dct2, dct3, dct4]) == expected
+    assert categorize_dict_keys([dct1, dct2, dct3], label_category) == expected
     assert (
-        concat_json_result([dct1, dct2, dct3, dct4], vote_option="majority_vote")
+        categorize_dict_keys([dct1, dct2, dct3], label_category, "majority_vote")
         == expected_majority_vote
     )
+
+
+def test_categorize_dict_keys_2():
+    data_path = (
+        "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
+    )
+    data = categorize_dict_keys(read_json(data_path), label_category)  # one dict
+    expected = {
+        "optim-optimizer": {"optim-optimizer-MomentumSGD"},
+        "optim-optimizer-momentum": {0.9},
+        "optim-learningrate": {0.4},
+        "optim-weightdecay": {0.0005},
+        "optim-lrscheduler": {"optim-lrscheduler-CosineAnnealingLR"},
+        "batchsize": {256},
+        "epochs": {300},
+        "resource-train-gpu": {"resource-train-gpu-T4"},
+        "resource-inference-gpu": {"resource-inference-gpu-T4"},
+    }
+    assert data == expected
+
+
+def test_categorize_dict_keys_3():
+    data_path = "tests/data/annotation_format.json"
+    data = categorize_dict_keys(read_json(data_path), label_category)  # empty dict
+    assert data == {}
+
+
+def test_categorize_dict_keys_4():
+    try:
+        categorize_dict_keys([{}], {}, "not_exist")
+    except ValueError:
+        pass
+    else:
+        assert 1
+
+
+def test_uncategorize_dict_keys_0():
+    dct = {
+        "optim-optimizer": {"optim-optimizer-Adam", "optim-optimizer-SGD"},
+        "optim-lrscheduler": {
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        },
+        "optim-weightdecay": {5e-5, 5e-4},
+        "epochs": {10, 20},
+        "iterations": {5510},
+    }
+    label_category = {
+        "optim-optimizer": ["optim-optimizer-Adam", "optim-optimizer-SGD"],
+        "optim-lrscheduler": [
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        ],
+        "optim-weightdecay": ["optim-weightdecay"],
+        "epochs": ["epochs"],
+        "iterations": ["iterations"],
+    }
+    expected = {
+        "optim-optimizer-Adam": True,
+        "optim-optimizer-SGD": True,
+        "optim-lrscheduler-LambdaLR": True,
+        "optim-lrscheduler-CosineAnnealingLR": True,
+        "optim-weightdecay": [5e-5, 5e-4],
+        "epochs": [10, 20],
+        "iterations": [5510],
+    }
+    output = uncategorize_dict_keys(dct, label_category)
+    for k, v in expected.items():
+        assert k in output
+        if isinstance(v, bool):
+            assert isinstance(output[k], bool) and output[k] == v
+        else:
+            assert isinstance(output[k], list) and set(output[k]) == set(v)
+
+
+def test_uncategorize_dict_keys_1():
+    dct = {
+        "optim-optimizer": set(),
+        "optim-lrscheduler": {
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        },
+        "optim-weightdecay": {5e-5, 5e-4, 5e-3},
+        "optim-earlystopping": {True},
+        "epochs": {10, 20},
+    }
+    label_category = {
+        "optim-optimizer": ["optim-optimizer-Adam", "optim-optimizer-SGD"],
+        "optim-lrscheduler": [
+            "optim-lrscheduler-LambdaLR",
+            "optim-lrscheduler-CosineAnnealingLR",
+        ],
+        "optim-weightdecay": ["optim-weightdecay"],
+        "optim-earlystopping": ["optim-earlystopping"],
+        "epochs": ["epochs"],
+        "iterations": ["iterations"],  # not include in dct
+    }
+    expected = {
+        "optim-lrscheduler-LambdaLR": True,
+        "optim-lrscheduler-CosineAnnealingLR": True,
+        "optim-weightdecay": [5e-5, 5e-4, 5e-3],
+        "optim-earlystopping": True,
+        "epochs": [10, 20],
+    }
+    output = uncategorize_dict_keys(dct, label_category)
+    for k, v in expected.items():
+        assert k in output
+        if isinstance(v, bool):
+            assert isinstance(output[k], bool) and output[k] == v
+        else:
+            assert isinstance(output[k], list) and set(output[k]) == set(v)


### PR DESCRIPTION
新しい評価方法と多数決の取り方に対応するための変更を行いました。
- `Metrics` クラスでは一つのカテゴリ分の正解/予測ペアを受け取り評価値を計算います。これを何度も呼ぶことで全体に対する評価値を得て、それらの平均を呼び出し元で取ることを想定しています。
- GPTからの解答の統合後を除き、全ての項目について高々一つの回答（正解）しかないはずなので、`clean_values()` などではイテラティブな値を扱わないこととしています。
