### PR TITLE
update 'categorize_dict_keys()' function to select a vote_option for each category independently

### DIFF
--- a/gptsenpy/utils/__init__.py
+++ b/gptsenpy/utils/__init__.py
@@ -1,6 +1,7 @@
 from .utils import (
     Num,
+    categorize_labels,
+    categorize_labels_with_dct,
     clean_values,
-    categorize_dict_keys,
     uncategorize_dict_keys,
 )

--- a/gptsenpy/utils/utils.py
+++ b/gptsenpy/utils/utils.py
@@ -111,14 +111,14 @@ def clean_values(
     return ret_dct
 
 
-def categorize_dict_keys(
+def categorize_labels(
     results: list[dict[str, Num]] | dict[str, Num],
     label_category: dict[str, list[str]],
-    vote_option: str | dict = "union",
+    vote_option: str = "union",
     keys: list[str] | None = None,
 ) -> dict[str, set[str | Num]]:
     """
-    Categorizes and aggregates dictionaries based on specified label categories and voting options.
+    Categorizes and aggregates dictionaries based on specified label categories and a string of voting option.
 
     Parameters
     ----------
@@ -126,10 +126,47 @@ def categorize_dict_keys(
         A dictionary or a list of dictionaries containing key-value pairs to be categorized.
     label_category : dict[str, list[str]]
         A dictionary mapping category names to lists of keys that belong to each category.
-    vote_option : str | dict, optional
+    vote_option : str, optional
         The voting method to use for aggregation. Supported options are "union" and "majority_vote".
-        When a str given, it's applied to all categories. When a dict is given, vote options are applied to the corresponding categories.
-        The default is "union".
+        The voting method is applied to all categories. The default is "union".
+    keys : list[str] | None, optional
+        A list of keys. The default is None.
+
+    Raises
+    ------
+    ValueError
+        If the provided `vote_option` is not based on supported voting methods.
+
+    Returns
+    -------
+    aggregated_result : dict[str, set[str | Num]]
+        A dictionary where each key corresponds to a category name, and the corresponding value is a set containing
+        the aggregated values from the keys belonging to that category.
+
+    """
+    return categorize_labels_with_dct(
+        results, label_category, {k: vote_option for k in label_category}, keys
+    )
+
+
+def categorize_labels_with_dct(
+    results: list[dict[str, Num]] | dict[str, Num],
+    label_category: dict[str, list[str]],
+    vote_option: dict,
+    keys: list[str] | None = None,
+) -> dict[str, set[str | Num]]:
+    """
+    Categorizes and aggregates dictionaries based on specified label categories and a dictionary of voting options for each category.
+
+    Parameters
+    ----------
+    results : list[dict[str, Num]] | dict[str, Num]
+        A dictionary or a list of dictionaries containing key-value pairs to be categorized.
+    label_category : dict[str, list[str]]
+        A dictionary mapping category names to lists of keys that belong to each category.
+    vote_option : dict
+        A dictionnary of voting method to use for aggregation, where keys are categories and values are one of supported voting options.
+        Supported options are "union" and "majority_vote".
     keys : list[str] | None, optional
         A list of keys. The default is None.
 
@@ -165,9 +202,6 @@ def categorize_dict_keys(
                     merged_result[category].append(cleaned_result[sub])
                 else:
                     merged_result[category].append(sub)
-
-    if isinstance(vote_option, str):
-        vote_option = {k: vote_option for k in merged_result.keys()}
 
     aggregated_result: dict[str, set[str | Num]] = dict()
     for c, v in merged_result.items():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,8 +5,7 @@ sys.path.append("../gptsenpy")
 
 from gptsenpy.io.read import read_json
 from gptsenpy.metrics import MetricGroup
-from gptsenpy.utils import categorize_dict_keys
-
+from gptsenpy.utils import categorize_labels
 
 with open("tests/data/label_category.json", "r") as f:
     LABEL_CATEGORY = json.load(f)
@@ -21,7 +20,7 @@ def calc_f1(recall, precision):
 
 def test_MetricGroup_0():
     data_path = "tests/data/annotation_format.json"
-    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+    data = categorize_labels(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup(data, data, LABEL_CATEGORY)
     mt()
@@ -47,7 +46,7 @@ def test_MetricGroup_1():
     data_path = (
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
-    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+    data = categorize_labels(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup(data, data, LABEL_CATEGORY)
     mt()
@@ -92,7 +91,7 @@ def test_MetricGroup_2():
     data_path = (
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
-    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+    data = categorize_labels(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup(data, {}, LABEL_CATEGORY)
     mt()
@@ -141,7 +140,7 @@ def test_MetricGroup_3():
     data_path = (
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
-    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+    data = categorize_labels(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup({}, data, LABEL_CATEGORY)
     mt()
@@ -265,7 +264,7 @@ def test_MetricGroup_5():
     data_path = (
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
-    data = categorize_dict_keys(read_json(data_path), LABEL_CATEGORY)
+    data = categorize_labels(read_json(data_path), LABEL_CATEGORY)
 
     mt = MetricGroup(data, data, [])
     mt()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,12 @@ import sys
 
 sys.path.append("../gptsenpy")
 from gptsenpy.io.read import read_json
-from gptsenpy.utils import categorize_dict_keys, clean_values, uncategorize_dict_keys
+from gptsenpy.utils import (
+    categorize_labels,
+    categorize_labels_with_dct,
+    clean_values,
+    uncategorize_dict_keys,
+)
 
 with open("tests/data/label_category.json", "r") as f:
     label_category = json.load(f)
@@ -75,7 +80,7 @@ def test_clean_values_4():
     assert clean_values(data, key_lst) == true_dct
 
 
-def test_categorize_dict_keys_0():
+def test_categorize_labels_0():
     dct1 = {
         "optim-optimizer-Adam": True,
         "optim-lrscheduler-LambdaLR": True,
@@ -129,13 +134,15 @@ def test_categorize_dict_keys_0():
         "epochs": {20},  # 'majority_vote'
         "iterations": {5510},  # 'union'
     }
-    assert categorize_dict_keys([dct1, dct2, dct3], label_category) == expected
+    assert categorize_labels([dct1, dct2, dct3], label_category) == expected
     assert (
-        categorize_dict_keys([dct1, dct2, dct3], label_category, "majority_vote")
+        categorize_labels(
+            [dct1, dct2, dct3], label_category, vote_option="majority_vote"
+        )
         == expected_majority_vote
     )
     assert (
-        categorize_dict_keys(
+        categorize_labels_with_dct(
             [dct1, dct2, dct3],
             label_category,
             {
@@ -150,7 +157,7 @@ def test_categorize_dict_keys_0():
     )
 
 
-def test_categorize_dict_keys_1():
+def test_categorize_labels_1():
     dct1 = {
         "optim-optimizer-Adam": False,
         "optim-lrscheduler-LambdaLR": True,
@@ -199,18 +206,20 @@ def test_categorize_dict_keys_1():
         "optim-earlystopping": {True},
         "epochs": {10, 20},
     }
-    assert categorize_dict_keys([dct1, dct2, dct3], label_category) == expected
+    assert categorize_labels([dct1, dct2, dct3], label_category) == expected
     assert (
-        categorize_dict_keys([dct1, dct2, dct3], label_category, "majority_vote")
+        categorize_labels(
+            [dct1, dct2, dct3], label_category, vote_option="majority_vote"
+        )
         == expected_majority_vote
     )
 
 
-def test_categorize_dict_keys_2():
+def test_categorize_labels_2():
     data_path = (
         "tests/data/DAMO-YOLO_A_Report_on_Real-Time_Object_Detection_Design.json"
     )
-    data = categorize_dict_keys(read_json(data_path), label_category)  # one dict
+    data = categorize_labels(read_json(data_path), label_category)  # one dict
     expected = {
         "optim-optimizer": {"optim-optimizer-MomentumSGD"},
         "optim-optimizer-momentum": {0.9},
@@ -225,15 +234,15 @@ def test_categorize_dict_keys_2():
     assert data == expected
 
 
-def test_categorize_dict_keys_3():
+def test_categorize_labels_3():
     data_path = "tests/data/annotation_format.json"
-    data = categorize_dict_keys(read_json(data_path), label_category)  # empty dict
+    data = categorize_labels(read_json(data_path), label_category)  # empty dict
     assert data == {}
 
 
-def test_categorize_dict_keys_4():
+def test_categorize_labels_4():
     try:
-        categorize_dict_keys(
+        categorize_labels(
             [{"A": True}], {"A": ["A"]}, vote_option="not_exist", keys=["A"]
         )
     except ValueError:
@@ -242,13 +251,13 @@ def test_categorize_dict_keys_4():
         assert 0
 
 
-def test_categorize_dict_keys_5():  # one dict, lacks "epochs" as a key
+def test_categorize_labels_5():  # one dict, lacks "epochs" as a key
     dct = {
         "optim-optimizer-Adam": True,
         "epochs": 10,
     }
     try:
-        categorize_dict_keys(dct, label_category, {"optim-optimizer": "union"})
+        categorize_labels_with_dct(dct, label_category, {"optim-optimizer": "union"})
     except ValueError:
         pass
     else:


### PR DESCRIPTION
ラベルの統合で、カテゴリごとに "union" または "majority_vote" を選択できるように変更しました。
カテゴリごとの指定はカテゴリをキーとし、統合方法を値とする辞書により行えます。
これまでの選択方法もそのまま使用できるため、今回変更を加えた `categorize_dict_keys()` を呼び出しているmoonshot側への影響はないはずです。